### PR TITLE
Require typescript@4.2.2 exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@dekkai/data-source": "^0.2.1",
-    "typescript": "^4.2.2",
+    "typescript": "4.2.2",
     "webidl2": "^23.13.1",
     "webidl2ts": "git+https://github.com/darionco/webidl2ts.git",
     "yargs": "^16.2.0"


### PR DESCRIPTION
Breaks with 4.2.3, which was installed for me when I did `npm install` in https://github.com/gpuweb/types.
Worked when I installed 4.2.2 specifically.